### PR TITLE
Raise BFT quorum minimum to four masternodes

### DIFF
--- a/consensus/src/quorum.rs
+++ b/consensus/src/quorum.rs
@@ -1,5 +1,5 @@
 //! Quorum calculation for TIME Coin consensus
-pub const MIN_MASTERNODES: usize = 3;
+pub const MIN_MASTERNODES: usize = 4;
 pub const GRACE_PERIOD_SECS: i64 = 1800;
 pub fn calculate_quorum(total_nodes: usize) -> usize {
     if total_nodes < MIN_MASTERNODES { return total_nodes; }

--- a/docs/whitepaper/TIME-Technical-Whitepaper.md
+++ b/docs/whitepaper/TIME-Technical-Whitepaper.md
@@ -55,6 +55,7 @@ TIME is a global payment network enabling cryptocurrency transactions through mu
 **Layer 1: Instant Validation Layer**
 - Masternode operators validate transactions immediately
 - Byzantine Fault Tolerant (BFT) consensus among active validators
+- Minimum 4 active masternodes required to form a quorum
 - Transactions confirmed in 1-3 seconds
 - Optimistic execution with fraud proofs
 

--- a/docs/whitepaper/TIME-Whitepaper.md
+++ b/docs/whitepaper/TIME-Whitepaper.md
@@ -71,6 +71,8 @@ Confirmed in <3 seconds → Irreversible finality
 
 **Dynamic Quorum Selection**: As the network scales to 100,000+ masternodes, intelligent quorum selection maintains sub-3-second finality.
 
+**Minimum Active Validators**: A BFT quorum activates only when at least 4 masternodes are online and voting.
+
 ### Universal Accessibility
 
 **SMS Payments**

--- a/docs/whitepaper/Technical-Whitepaper-v3.0.md
+++ b/docs/whitepaper/Technical-Whitepaper-v3.0.md
@@ -251,6 +251,8 @@ Comparison:
 
 ### Modified Byzantine Fault Tolerant (BFT)
 
+- Minimum of 4 active masternodes required to initiate a voting round
+
 #### Core Algorithm
 
 **Consensus Phases:**

--- a/docs/whitepaper/Whitepaper-Overview-v3.0.md
+++ b/docs/whitepaper/Whitepaper-Overview-v3.0.md
@@ -67,6 +67,8 @@ Confirmed in <3 seconds → Irreversible finality
 
 **Dynamic Quorum Selection**: As the network scales to 100,000+ masternodes, intelligent quorum selection maintains sub-3-second finality.
 
+**Minimum Active Validators**: The BFT quorum forms only when at least 4 masternodes are online and participating.
+
 ### Universal Accessibility
 
 **SMS Payments**


### PR DESCRIPTION
## Summary
- raise the consensus minimum masternode count to four before forming a quorum
- document the four-node minimum across the whitepaper set

## Testing
- cargo test -p time-consensus

------
https://chatgpt.com/codex/tasks/task_e_68f6533c6c6c832fbff56094dd0560d6