### PR TITLE
Fix merkle root calculation mismatch between producer and validator

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,3 +39,4 @@ time-mempool = { version = "0.1.0", path = "../mempool" }
 wallet = { version = "0.1.0", path = "../wallet" }
 sysinfo = "0.29"
 crossterm = "0.27"
+sha3.workspace = true


### PR DESCRIPTION
Fixes BlockError(InvalidMerkleRoot) by making BlockProducer.calc_merkle() use the same SHA3-256 merkle tree algorithm as Block.calculate_merkle_root()